### PR TITLE
Add ceph version data collection playbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Jordan is an Infrared plugin testing a RHOSP Director-deployed Ceph cluster, its state, its configuration, and its topology.
 The tests are separated by sections, defined by `main.yml`:
+  - ceph version data (`get_ceph_version.yml`)
   - overall cluster state (`cluster.yml`)
   - OSDs state (`osds.yml`)
   - pool configuration (`pools.yml`)

--- a/get_ceph_version.yml
+++ b/get_ceph_version.yml
@@ -1,0 +1,49 @@
+---
+- name: Get ceph version
+  hosts: undercloud-0
+  tasks:
+    - name: register Ceph version
+      shell: "{{test.ceph.reg.provider}} exec ceph-mon-`hostname -s` ceph --cluster {{test.cluster.name}} --version | awk '{print$3}'"
+      become: true
+      register: ceph_version
+      run_once: yes
+      tags:
+        - sanity
+        - containerized
+
+    - name: print Ceph version
+      debug:
+        msg: "Build Mark: ceph_version={{ceph_version.stdout}}"
+
+    - name: log Ceph version
+      lineinfile:
+        path: "{{ test.output.file }}"
+        line: "ceph_version={{ceph_version.stdout}}"
+      delegate_to: undercloud-0
+      run_once: yes
+      tags:
+        - sanity
+        - containerized
+
+    - name: get packages from undercloud
+      package_facts:
+        manager: "auto"
+
+    - name: print the package facts
+      debug:
+        var: ansible_facts.packages
+
+    - name: print ceph-ansible rpm version
+      debug:
+        msg: "{{ ansible_facts.packages['ceph-ansible'].0.version }}"
+      when: "'ceph-ansible' in ansible_facts.packages"
+
+    - name: log Ceph-Ansible version
+      lineinfile:
+        path: "{{ test.output.file }}"
+        line: "ceph_ansible_version={{ ansible_facts.packages['ceph-ansible'].0.version }}"
+      delegate_to: undercloud-0
+      run_once: yes
+      tags:
+        - sanity
+        - containerized

--- a/main.yml
+++ b/main.yml
@@ -4,6 +4,8 @@
 
 - import_playbook: "{{ initialize_log | default('initialize_results_file.yml')}}"
 
+- import_playbook: "{{ get_ceph_version | default('get_ceph_version.yml') }}"
+
 - import_playbook: "{{ cluster_check | default('cluster.yml') }}"
 
 - import_playbook: "{{ osds_check | default('osds.yml') }}"


### PR DESCRIPTION
The  ceph_version and ceph_ansible_version playbooks will collect the relevant version data for reporting purposes 